### PR TITLE
Change success output from optionName to optionId

### DIFF
--- a/Routes/dashboard.js
+++ b/Routes/dashboard.js
@@ -494,7 +494,7 @@ module.exports = (app, config, themeConfig) => {
                                         option.optionId
                                     )
                                 } else {
-                                    successes.push(option.optionName)
+                                    successes.push(option.optionId)
                                 }
                             } else if (
                                 typeof req.body[option.optionId] != "object"
@@ -520,7 +520,7 @@ module.exports = (app, config, themeConfig) => {
                                         option.optionId
                                     )
                                 } else {
-                                    successes.push(option.optionName)
+                                    successes.push(option.optionId)
                                 }
                             } else {
                                 setNewRes = await option.setNew({
@@ -544,7 +544,7 @@ module.exports = (app, config, themeConfig) => {
                                         option.optionId
                                     )
                                 } else {
-                                    successes.push(option.optionName)
+                                    successes.push(option.optionId)
                                 }
                             }
                         } else if (option.optionType.type == "switch") {
@@ -579,7 +579,7 @@ module.exports = (app, config, themeConfig) => {
                                             option.optionId
                                         )
                                     } else {
-                                        successes.push(option.optionName)
+                                        successes.push(option.optionId)
                                     }
                                 } else {
                                     setNewRes =
@@ -604,7 +604,7 @@ module.exports = (app, config, themeConfig) => {
                                             option.optionId
                                         )
                                     } else {
-                                        successes.push(option.optionName)
+                                        successes.push(option.optionId)
                                     }
                                 }
                             }
@@ -635,7 +635,7 @@ module.exports = (app, config, themeConfig) => {
                                         option.optionId
                                     )
                                 } else {
-                                    successes.push(option.optionName)
+                                    successes.push(option.optionId)
                                 }
                             } else {
                                 try {
@@ -664,7 +664,7 @@ module.exports = (app, config, themeConfig) => {
                                             option.optionId
                                         )
                                     } else {
-                                        successes.push(option.optionName)
+                                        successes.push(option.optionId)
                                     }
                                 } catch (err) {
                                     setNewRes =
@@ -691,7 +691,7 @@ module.exports = (app, config, themeConfig) => {
                                             option.optionId
                                         )
                                     } else {
-                                        successes.push(option.optionName)
+                                        successes.push(option.optionId)
                                     }
                                 }
                             }
@@ -722,7 +722,7 @@ module.exports = (app, config, themeConfig) => {
                                         option.optionId
                                     )
                                 } else {
-                                    successes.push(option.optionName)
+                                    successes.push(option.optionId)
                                 }
                             } else {
                                 setNewRes =
@@ -747,7 +747,7 @@ module.exports = (app, config, themeConfig) => {
                                         option.optionId
                                     )
                                 } else {
-                                    successes.push(option.optionName)
+                                    successes.push(option.optionId)
                                 }
                             }
                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "discord-dashboard",
-    "version": "2.3.61",
+    "version": "2.3.63",
     "description": "Create an Dashboard for your bot in 10 minutes without APIs knowledge and slapping code from scratch!",
     "main": "index.js",
     "directories": {


### PR DESCRIPTION
Currently guildSettingsUpdated returns this:

```
user: {
    id: '',
    username: 'ryans',
    avatar: 'd0ad2238c64904958f97e405bdfff81a',
    discriminator: '0',
    public_flags: 4194560,
    premium_type: 3,
    flags: 4194560,
    banner: null,
    accent_color: 10939173,
    global_name: 'Ryan',
    avatar_decoration_data: {
      asset: 'a_fed43ab12698df65902ba06727e20c0e',
      sku_id: '1144058844004233369'
    },
    banner_color: '#a6eb25',
    mfa_enabled: true,
    locale: 'en-US',
    tag: 'ryanmbananas#0',
    avatarURL: 'https://cdn.discordapp.com/avatars/511712943906226229/d0ad2238c64904958f97e405bdfff81a.png?size=1024'
  },
  changes: { successes: [ 'Primary Logs' ], errors: [] },
  guildId: '1177284212781490327'
}
```

I changed it to this to make working with it easier

```
user: {
    id: '',
    username: 'ryan',
    avatar: 'd0ad2238c64904958f97e405bdfff81a',
    discriminator: '0',
    public_flags: 4194560,
    premium_type: 3,
    flags: 4194560,
    banner: null,
    accent_color: 10939173,
    global_name: 'Ryans',
    avatar_decoration_data: {
      asset: 'a_fed43ab12698df65902ba06727e20c0e',
      sku_id: '1144058844004233369'
    },
    banner_color: '#a6eb25',
    mfa_enabled: true,
    locale: 'en-US',
    tag: 'ryan',
    avatarURL: 'https://cdn.discordapp.com/avatars/511712943906226229/d0ad2238c64904958f97e405bdfff81a.png?size=1024'
  },
  changes: { successes: [ 'prmLogs' ], errors: [] },
  guildId: '1177284212781490327'
}
```